### PR TITLE
Add properties for Redis user and password

### DIFF
--- a/peppol-reporting-backend-redis/src/main/java/com/helper/peppol/reporting/backend/redis/PeppolReportingBackendRedisSPI.java
+++ b/peppol-reporting-backend-redis/src/main/java/com/helper/peppol/reporting/backend/redis/PeppolReportingBackendRedisSPI.java
@@ -59,6 +59,8 @@ public class PeppolReportingBackendRedisSPI implements IPeppolReportingBackendSP
 {
   public static final String CONFIG_PEPPOL_REPORTING_REDIS_HOST = "peppol.reporting.redis.host";
   public static final String CONFIG_PEPPOL_REPORTING_REDIS_PORT = "peppol.reporting.redis.port";
+  public static final String CONFIG_PEPPOL_REPORTING_REDIS_USER = "peppol.reporting.redis.user";
+  public static final String CONFIG_PEPPOL_REPORTING_REDIS_PASSWORD = "peppol.reporting.redis.password";
   public static final int DEFAULT_REDIS_PORT = 6379;
 
   private static final Logger LOGGER = LoggerFactory.getLogger (PeppolReportingBackendRedisSPI.class);
@@ -97,7 +99,10 @@ public class PeppolReportingBackendRedisSPI implements IPeppolReportingBackendSP
     }
 
     LOGGER.info ("Using Peppol Reporting Redis at '" + sHost + ":" + nPort + "'");
-    return new JedisPool (sHost, nPort);
+    final String username = aConfig.getAsString(CONFIG_PEPPOL_REPORTING_REDIS_USER);
+    final String password = aConfig.getAsString(CONFIG_PEPPOL_REPORTING_REDIS_PASSWORD);
+
+    return new JedisPool(sHost, nPort, username, password);
   }
 
   @Nonnull

--- a/peppol-reporting-backend-redis/src/test/resources/application.properties
+++ b/peppol-reporting-backend-redis/src/test/resources/application.properties
@@ -18,3 +18,5 @@
 # Redis specific settings
 peppol.reporting.redis.host = localhost
 peppol.reporting.redis.port = 6379
+peppol.reporting.redis.user = default
+peppol.reporting.redis.password = password

--- a/unittest-db-docker-compose.yml
+++ b/unittest-db-docker-compose.yml
@@ -34,7 +34,7 @@ services:
     restart: always
     ports:
       - "6379:6379"
-#    command: redis-server --save 20 1 --loglevel warning --requirepass eYVX7EwVmmxKPCDmwMtyKVge8oLd2t81
+    # command: redis-server --requirepass password --save 20 1 --loglevel warning
     command: redis-server --save 20 1 --loglevel warning
     volumes: 
       - redis:/data


### PR DESCRIPTION
closes #12 

As we discussed in https://github.com/phax/peppol-reporting/discussions/12, this pull request adds properties for Redis 
user and password. They are optional and can be null.