### PR TITLE
feat: add experimental IBM DB2 support to SQL backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Submodule `peppol-reporting-backend-sql` stores data in relational databases.
 This submodule was introduced in version 3.0.1.
 
 It supports the following configuration properties:
-* **`peppol.reporting.jdbc.database-type`**: the SQL database type to operate on. Currently supported are `postgresql`, `mysql` and `sqlserver`. The value is case-insensitive.
+* **`peppol.reporting.jdbc.database-type`**: the SQL database type to operate on. Currently supported are `postgresql`, `mysql`, `sqlserver` and (experimentally) `db2`. The value is case-insensitive.
 * **`peppol.reporting.jdbc.driver`**: contains the fully qualified class name of the JDBC driver to be used. E.g. `org.postgresql.Driver` for PostgreSQL, `com.mysql.cj.jdbc.Driver` for MySQL or `com.microsoft.sqlserver.jdbc.SQLServerDriver` for SQL Server
 * **`peppol.reporting.jdbc.url`**: contains the full JDBC connection URL to connect to the database
 * **`peppol.reporting.jdbc.user`** (optional): the database username to use
@@ -169,6 +169,15 @@ SQL Server:
       <groupId>com.microsoft.sqlserver</groupId>
       <artifactId>mssql-jdbc</artifactId>
       <version>x.y.z</version>
+    </dependency>
+```
+
+DB2 (Experimental):
+```xml
+    <dependency>
+      <groupId>com.ibm.db2</groupId>
+      <artifactId>jcc</artifactId>
+      <version>11.5.9.0</version>
     </dependency>
 ```
 

--- a/peppol-reporting-backend-sql/pom.xml
+++ b/peppol-reporting-backend-sql/pom.xml
@@ -86,6 +86,12 @@
       <artifactId>flyway-sqlserver</artifactId>
       <version>${flyway.version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.flywaydb</groupId>
+      <artifactId>flyway-database-db2</artifactId>
+      <version>${flyway.version}</version>
+      <optional>true</optional>
+    </dependency>
     
     <dependency>
       <groupId>com.helger.peppol</groupId>
@@ -118,6 +124,12 @@
       <groupId>com.microsoft.sqlserver</groupId>
       <artifactId>mssql-jdbc</artifactId>
       <version>13.4.0.jre11</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.ibm.db2</groupId>
+      <artifactId>jcc</artifactId>
+      <version>11.5.9.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/peppol-reporting-backend-sql/src/main/java/com/helger/peppol/reporting/backend/sql/PeppolReportingBackendSqlSPI.java
+++ b/peppol-reporting-backend-sql/src/main/java/com/helger/peppol/reporting/backend/sql/PeppolReportingBackendSqlSPI.java
@@ -65,7 +65,8 @@ public class PeppolReportingBackendSqlSPI implements IPeppolReportingBackendSPI
   private static final Logger LOGGER = LoggerFactory.getLogger (PeppolReportingBackendSqlSPI.class);
   private static final EnumSet <EDatabaseSystemType> ALLOWED_DB_TYPES = EnumSet.of (EDatabaseSystemType.MYSQL,
                                                                                     EDatabaseSystemType.POSTGRESQL,
-                                                                                    EDatabaseSystemType.SQLSERVER);
+                                                                                    EDatabaseSystemType.SQLSERVER,
+                                                                                    EDatabaseSystemType.DB2);
 
   private final SimpleReadWriteLock m_aRWLock = new SimpleReadWriteLock ();
   @GuardedBy ("m_aRWLock")

--- a/peppol-reporting-backend-sql/src/main/resources/db/reporting-db2/V1__Initial-DB2.sql
+++ b/peppol-reporting-backend-sql/src/main/resources/db/reporting-db2/V1__Initial-DB2.sql
@@ -1,0 +1,36 @@
+--
+-- Copyright (C) 2023-2026 Philip Helger
+-- philip[at]helger[dot]com
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--         http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
+CREATE TABLE peppol_reporting_item (
+  exchangedt timestamp    NOT NULL,
+  sending    smallint     NOT NULL,
+  c2id       varchar(64)  NOT NULL,
+  c3id       varchar(64)  NOT NULL,
+  dtscheme   varchar(64)  NOT NULL,
+  dtvalue    varchar(500) NOT NULL,
+  procscheme varchar(64)  NOT NULL,
+  procvalue  varchar(200) NOT NULL,
+  tp         varchar(64)  NOT NULL,
+  c1cc       varchar(2)   NOT NULL,
+  c4cc       varchar(2)   DEFAULT NULL,
+  enduserid  varchar(256) NOT NULL
+);
+
+CREATE INDEX peppol_reporting_item_idx ON peppol_reporting_item (exchangedt);
+
+-- REORG TABLE is generally required in DB2 after structural changes, 
+-- but not strictly necessary for table creation.

--- a/peppol-reporting-backend-sql/src/test/java/com/helger/peppol/reporting/backend/sql/PeppolReportingBackendDb2SPITest.java
+++ b/peppol-reporting-backend-sql/src/test/java/com/helger/peppol/reporting/backend/sql/PeppolReportingBackendDb2SPITest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2023-2026 Philip Helger
+ * philip[at]helger[dot]com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.helger.peppol.reporting.backend.sql;
+
+import org.jspecify.annotations.NonNull;
+
+/**
+ * SPI contract test for {@link PeppolReportingBackendSqlSPI} against DB2.
+ *
+ * @author Philip Helger
+ */
+public final class PeppolReportingBackendDb2SPITest extends AbstractPeppolReportingBackendSqlSPITest
+{
+  @Override
+  @NonNull
+  protected String getConfigFileName ()
+  {
+    return "application-db2.properties";
+  }
+}

--- a/peppol-reporting-backend-sql/src/test/resources/application-db2.properties
+++ b/peppol-reporting-backend-sql/src/test/resources/application-db2.properties
@@ -1,0 +1,23 @@
+#
+# Copyright (C) 2023-2026 Philip Helger
+# philip[at]helger[dot]com
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+peppol.reporting.jdbc.database-type=db2
+peppol.reporting.jdbc.driver=com.ibm.db2.jcc.DB2Driver
+peppol.reporting.jdbc.url=jdbc:db2://localhost:50000/phossrep
+peppol.reporting.jdbc.user=db2inst1
+peppol.reporting.jdbc.password=peppol
+peppol.reporting.jdbc.schema=


### PR DESCRIPTION
### Title:
feat: add experimental IBM DB2 support to SQL backend

### Description:
This PR adds experimental IBM DB2 LUW support as a new database dialect for the `peppol-reporting-backend-sql` module.

It follows the same established patterns as other projects in this ecosystem (specifically matching `phoss-smp`'s DB2 implementation and `phoss-ap` PR #57):

- **Database Dialect**: Added `EDatabaseSystemType.DB2` to the allowed SQL database types in the SPI.
- **Dependencies**: Added `flyway-database-db2` and `com.ibm.db2:jcc` to `pom.xml` as optional/test scope to avoid forcing the IBM driver on downstream consumers.
- **Flyway Migrations**: Created a `db/reporting-db2/` migration folder containing the initial schema tailored for DB2:
  - Boolean values mapped to `SMALLINT` (`0`/`1`).
  - Timestamps mapped to DB2 `TIMESTAMP`.
- **Testing**: Added integration test properties (`application-db2.properties` with generic defaults) and the test class `PeppolReportingBackendDb2SPITest` to verify database capabilities against DB2.
- **Documentation**: Updated `README.md` documenting DB2 configuration properties.

Closes #20
